### PR TITLE
fix: TOC alignment, scroll jerk, table centering, bottom whitespace

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -2240,7 +2240,7 @@ body.theme-setting-embeddedNoteTitleVisibilityShow .embed-title {
 .markdown-source-view.mod-cm6
   .cm-content
   > .markdown-embed[contenteditable="false"]:has(.markdown-embed-link) {
-  contain: layout !important;
+  position: relative;
 }
 .markdown-embed-link {
   position: absolute;
@@ -2461,7 +2461,7 @@ audio::-webkit-media-controls-panel {
 }
 body:not(.is-mobile) {
   .cm-content .cm-embed-block[contenteditable="false"]:has(.edit-block-button) {
-    contain: layout !important;
+    position: relative;
   }
   /* Move edit controls to the sidebar outside the block */
   .cm-content .cm-embed-block .edit-block-button,
@@ -4605,9 +4605,10 @@ p.mod-warning:has(+ p.mod-warning, .setting-message),
   margin: 0;
   position: relative;
 }
-/* These are set the same so we can use consistent em unites for spacing */
-.tree-item-self,
-.tree-item-children {
+/* Only set on tree-item-self, not tree-item-children — setting font-size on
+   tree-item-children causes it to compound at each nesting level, shrinking
+   em-based indentation and misaligning the TOC outline */
+.tree-item-self {
   font-size: var(--nav-item-size);
 }
 /* #endregion */
@@ -6153,19 +6154,36 @@ body.theme-setting-enableIconsInSettings {
   width: 100%;
   max-width: 100%;
 
-  > div {
-    /* TODO: need to redefine --file-line-width so it's based on root character width, not base don current font size */
-    margin: 0 auto !important;
-    max-width: var(--file-line-width);
+  > div:not(.cm-table-widget) {
+    box-sizing: border-box;
+    padding-inline: max(1rem, calc((100% - var(--file-line-width)) / 2));
+  }
+
+  > .cm-table-widget {
+    padding-inline: 0;
+
+    > .table-wrapper {
+      box-sizing: border-box;
+      margin: 0 auto;
+      max-width: var(--file-line-width);
+    }
   }
 }
 .markdown-preview-view .markdown-preview-sizer {
-  > div {
-    margin: 0 auto !important;
-    max-width: var(--file-line-width);
-    padding: 0 2rem;
-
+  > div:not(.el-table) {
+    box-sizing: border-box;
+    padding-inline: max(2rem, calc((100% - var(--file-line-width)) / 2));
   }
+
+  > .el-table {
+    padding-inline: 0;
+
+    > table {
+      margin: 0 auto;
+      max-width: var(--file-line-width);
+    }
+  }
+
   > div.mod-header,
   > div.mod-footer {
     margin: 0;
@@ -6177,21 +6195,13 @@ body.theme-setting-enableIconsInSettings {
 /* Allow tables to extend into the left and right margins */
 .theme-setting-wideTables {
   .markdown-source-view.is-live-preview.mod-cm6.is-readable-line-width .cm-content {
-    > .cm-table-widget {
+    > .cm-table-widget > .table-wrapper {
       max-width: 100%;
-
-      > .table-wrapper {
-        margin: 0 auto;
-      }
     }
   }
   .markdown-preview-view .markdown-preview-sizer {
-    > .el-table {
+    > .el-table > table {
       max-width: 100%;
-
-      > table {
-        margin: 0 auto;
-      }
     }
   }
 }
@@ -6208,13 +6218,12 @@ body.theme-setting-enableIconsInSettings {
 .is-phone .markdown-rendered .mod-header {
   margin-bottom: 0;
 }
-/* Override inline styles */
+/* Override inline styles — Obsidian injects a large padding-bottom on these
+   as inline styles; zero it out so the page ends where content ends */
 .cm-content {
-  /* Live Preview */
   padding-bottom: 0 !important;
 }
 .markdown-preview-sizer {
-  /* Reading Mode */
   padding-bottom: 0 !important;
 }
 


### PR DESCRIPTION
Related to #16 

## Bug Fixes

### TOC/Outline panel misalignment
The outline panel nested items were misaligned because `font-size: var(--nav-item-size)` 
was set on both `.tree-item-self` and `.tree-item-children`. Since `.tree-item-children` 
is a child of `.tree-item-self`, the font-size compounds at each nesting level, causing 
`em`-based indentation to shrink progressively. Fixed by removing it from `.tree-item-children`.

### Mid-scroll jerk in Live Preview
`margin: 0 auto !important` was applied to every content block inside `.cm-content`. 
CodeMirror uses virtual scrolling — blocks are created/destroyed as they enter the viewport. 
`margin: auto` requires a full layout reflow to resolve, causing a visible jerk each time 
a block is virtualised. Replaced with `padding-inline` calc which resolves without reflow.

### Table left-alignment regression
As a consequence of the centering fix above, tables needed separate handling. 
`.cm-table-widget` is a full-width block — applying `padding-inline` to it shrinks 
the container but the table anchors to the left edge. Fixed by keeping the widget 
full-width and centering the inner `.table-wrapper` with `margin: 0 auto` instead.

### `contain: layout` breaking scroll height estimation
`contain: layout !important` on embed blocks isolates their layout from the document, 
preventing CodeMirror from accurately measuring block heights. Replaced with 
`position: relative` which was the actual intent (to allow absolutely-positioned 
edit buttons to escape the block).

Tested in Live Preview and Reading mode with readable line length enabled.
Tables, wide tables setting, embeds, and TOC outline all verified working.